### PR TITLE
I0010 fix goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       if: steps.tag-commit.outputs.next-version != ''
       with:
-        args: release --clean
+        args: release --clean --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       if: steps.tag-commit.outputs.next-version != ''
       with:
-        args: --debug release --clean
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       if: steps.tag-commit.outputs.next-version != ''
       with:
-        args: release --clean --verbose
+        args: --verbose release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       if: steps.tag-commit.outputs.next-version != ''
       with:
-        args: --verbose release --clean
+        args: --debug release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
     env:
       - CGO_ENABLED=0
     flags:
-      - '{{ if eq .CurrentOS "windows" }}-tags=timetzdata{{ end }}'
+      - '{{ if eq .Os "windows" }}-tags=timetzdata{{ end }}'
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,6 @@ builds:
     main: ./cmd/nr-entity-tag-sync/nr-entity-tag-sync.go
     env:
       - CGO_ENABLED=0
-    flags:
-      - '{{ if eq .Os "windows" }}-tags=timetzdata{{ end }}'
     goos:
       - linux
       - windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,14 @@ builds:
     goarch:
       - "386"
       - amd64
+    overrides:
+      - goos: windows
+        goarch: ''
+        goamd64: ''
+        goarm: ''
+        gomips: ''
+        flags:
+        - '-tags timetzdata'
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,11 +21,11 @@ builds:
       - goos: windows
         goarch: "386"
         flags:
-        - '-tags timetzdata'
+        - '-tags=timetzdata'
       - goos: windows
         goarch: amd64
         flags:
-        - '-tags timetzdata'
+        - '-tags=timetzdata'
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,10 +19,11 @@ builds:
       - amd64
     overrides:
       - goos: windows
-        goarch: ''
-        goamd64: ''
-        goarm: ''
-        gomips: ''
+        goarch: "386"
+        flags:
+        - '-tags timetzdata'
+      - goos: windows
+        goarch: amd64
         flags:
         - '-tags timetzdata'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,7 @@ builds:
         - '-tags=timetzdata'
       - goos: windows
         goarch: amd64
+        goamd64: v1
         flags:
         - '-tags=timetzdata'
 


### PR DESCRIPTION
# Description

Fix the`.goreleaser.yaml` so that windows builds embed the timezone database.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Build fix

# Checklist:

Build fix only
