### PR TITLE
Utility startup details added

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ or as an AWS Lambda function.
    for your platform
 2. Extract the archive to a new directory
 3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml)
-4. Set the appropriate environment variables
+   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ or as an AWS Lambda function.
 1. Download [the latest release](https://github.com/newrelic/nr-entity-tag-sync/releases)
    for your platform
 2. Extract the archive to a new directory
-3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+3. Make a copy of config.yml from [the sample configuration file](configs/config.sample.yml) and place it 
+   inside 'configs' folder created at same folder location as the CMDB utility executable.
 4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ or as an AWS Lambda function.
 2. Extract the archive to a new directory
 3. Create a new configuration file from
    [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
-4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
+4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation


### PR DESCRIPTION
# Description

Following are details of PR : 
--------------------------

1) Added documentation detailing the file location for config.yml ( ./configs/config.yml)
2) Environment variable for license key ('NEW_RELIC_LICENSE_KEY') should be added during setup. When missing the utility fails with error that license key needs to be of length 40. After adding the environment variable the utility starts up properly. 

