### PR TITLE
Changes to support additional SNow Query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ or as an AWS Lambda function.
    for your platform
 2. Extract the archive to a new directory
 3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml)
-4. Set the appropriate environment variables
+   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ entities.
 | --- | --- | --- | --- | --- |
 | `type` | The ServiceNow CMDB configuration item type name | Y | `cmdb_ci_email_server` | |
 | `query` | An [encoded query string](https://docs.servicenow.com/csh?topicname=c_EncodedQueryStrings&version=utah&pubname=utah-platform-user-interface) to use to filter the result using  the `sysparm_query` parameter | N | `sys_updated_on>javascript:gs.dateGenerate('{{ .lastUpdateDate }}','{{ .lastUpdateTime }}')^operational_status!=2` | |
+| `extraQueryParms` | Additional Service Now [query params](https://docs.servicenow.com/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html) other than `sysparm_query` parameter | N | `&sysparm_display_value=true&sysparm_exclude_reference_link=true` | |
 | `serverTimezone` | A [location name](https://pkg.go.dev/time#LoadLocation) corresponding to a file in the IANA Time Zone database for the time zone of the local ServiceNow instance | N | `America/New_York` | |
 
 The ServiceNow CMDB query is executed by querying the `table` API using a URL

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ entities.
 | --- | --- | --- | --- | --- |
 | `type` | The ServiceNow CMDB configuration item type name | Y | `cmdb_ci_email_server` | |
 | `query` | An [encoded query string](https://docs.servicenow.com/csh?topicname=c_EncodedQueryStrings&version=utah&pubname=utah-platform-user-interface) to use to filter the result using  the `sysparm_query` parameter | N | `sys_updated_on>javascript:gs.dateGenerate('{{ .lastUpdateDate }}','{{ .lastUpdateTime }}')^operational_status!=2` | |
-| `extraQueryParms` | Additional Service Now [query params](https://docs.servicenow.com/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html) other than `sysparm_query` parameter | N | `&sysparm_display_value=true&sysparm_exclude_reference_link=true` | |
+| `optionalParams` | Add optional Service Now [query params](https://docs.servicenow.com/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html) other than `sysparm_query` parameter separated by ampersand ('&') | N | `sysparm_display_value=true&sysparm_exclude_reference_link=true` | |
 | `serverTimezone` | A [location name](https://pkg.go.dev/time#LoadLocation) corresponding to a file in the IANA Time Zone database for the time zone of the local ServiceNow instance | N | `America/New_York` | |
 
 The ServiceNow CMDB query is executed by querying the `table` API using a URL

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ or as an AWS Lambda function.
 1. Download [the latest release](https://github.com/newrelic/nr-entity-tag-sync/releases)
    for your platform
 2. Extract the archive to a new directory
-3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+3. Make a copy of config.yml from [the sample configuration file](configs/config.sample.yml) and place it 
+   inside 'configs' folder created at same folder location as the CMDB utility executable.
 4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ or as an AWS Lambda function.
 2. Extract the archive to a new directory
 3. Create a new configuration file from
    [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
-4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
+4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/internal/provider/servicenow/api.go
+++ b/internal/provider/servicenow/api.go
@@ -90,7 +90,7 @@ func (snp *ServiceNowProvider) getPaginatedResults(
 func (snp *ServiceNowProvider) getRecords(
 	tableName string,
 	query string,
-	extraQueryParms string,
+	optionalParams string,
 	fields []string,
 ) (
 	[]map[string]interface{},
@@ -119,8 +119,10 @@ func (snp *ServiceNowProvider) getRecords(
 		sysparmQuery,
 	)
 
-	if extraQueryParms != "" {
-		url = url+ extraQueryParms
+	if optionalParams != "" {
+		url = fmt.Sprintf("%s&%s",
+		url,
+		optionalParams)
 	}
 
 	for !done {
@@ -140,6 +142,7 @@ func (snp *ServiceNowProvider) getRecords(
 
 		url = nextUrl
 	}
+
 	return results, nil
 }
 

--- a/internal/provider/servicenow/api.go
+++ b/internal/provider/servicenow/api.go
@@ -90,6 +90,7 @@ func (snp *ServiceNowProvider) getPaginatedResults(
 func (snp *ServiceNowProvider) getRecords(
 	tableName string,
 	query string,
+	extraQueryParms string,
 	fields []string,
 ) (
 	[]map[string]interface{},
@@ -118,6 +119,10 @@ func (snp *ServiceNowProvider) getRecords(
 		sysparmQuery,
 	)
 
+	if extraQueryParms != "" {
+		url = url+ extraQueryParms
+	}
+
 	for !done {
 		records := &Records{}
 
@@ -135,7 +140,6 @@ func (snp *ServiceNowProvider) getRecords(
 
 		url = nextUrl
 	}
-
 	return results, nil
 }
 

--- a/internal/provider/servicenow/servicenow.go
+++ b/internal/provider/servicenow/servicenow.go
@@ -165,9 +165,9 @@ func (snp *ServiceNowProvider) GetEntities(
 		newTags = append(newTags, tag)
 	}
 
-	ciextraQueryParms := cast.ToString(config["extraqueryparms"])
+	ciOptionalParams := cast.ToString(config["optionalparams"])
 
-	items, err := snp.getRecords(ciType, ciQuery, ciextraQueryParms, newTags)
+	items, err := snp.getRecords(ciType, ciQuery, ciOptionalParams, newTags)
 	if err != nil {
 		return nil, fmt.Errorf("get records failed: %s", err)
 	}

--- a/internal/provider/servicenow/servicenow.go
+++ b/internal/provider/servicenow/servicenow.go
@@ -165,7 +165,7 @@ func (snp *ServiceNowProvider) GetEntities(
 		newTags = append(newTags, tag)
 	}
 
-	ciextraQueryParms := cast.ToString(config["extraQueryParms"])
+	ciextraQueryParms := cast.ToString(config["extraqueryparms"])
 
 	items, err := snp.getRecords(ciType, ciQuery, ciextraQueryParms, newTags)
 	if err != nil {

--- a/internal/provider/servicenow/servicenow.go
+++ b/internal/provider/servicenow/servicenow.go
@@ -165,7 +165,9 @@ func (snp *ServiceNowProvider) GetEntities(
 		newTags = append(newTags, tag)
 	}
 
-	items, err := snp.getRecords(ciType, ciQuery, newTags)
+	ciextraQueryParms := cast.ToString(config["extraQueryParms"])
+
+	items, err := snp.getRecords(ciType, ciQuery, ciextraQueryParms, newTags)
 	if err != nil {
 		return nil, fmt.Errorf("get records failed: %s", err)
 	}


### PR DESCRIPTION
# Description

Code changes to support standard Service Now query parameters other than 'sysparm_query'. The query parameters are documented in Service Now [documentation](https://docs.servicenow.com/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html) in  'Query Parameters'  table  under 'Table - GET /now/table/{tableName}' section.

Current Behaviour: 
The parameters mentioned below are not supported in current setup.

- sysparm_display_value
- sysparm_exclude_reference_link
- sysparm_no_count
- sysparm_query_category
- sysparm_suppress_pagination_header
- sysparm_view

New Behaviour
The above mentioned parameters can be added under 'extraQueryParms' in config.yaml as normal non encoded query parameters separated by ampersand(&)