### PR TITLE
Read license key from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ or as an AWS Lambda function.
    for your platform
 2. Extract the archive to a new directory
 3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml)
-4. Set the appropriate environment variables
+   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 ![GitHub forks](https://img.shields.io/github/forks/newrelic/nr-entity-tag-sync?style=social)
-:![GitHub stars](https://img.shields.io/github/stars/newrelic/nr-entity-tag-sync?style=social)
+![GitHub stars](https://img.shields.io/github/stars/newrelic/nr-entity-tag-sync?style=social)
 ![GitHub watchers](https://img.shields.io/github/watchers/newrelic/nr-entity-tag-sync?style=social)
 
 ![GitHub all releases](https://img.shields.io/github/downloads/newrelic/nr-entity-tag-sync/total)

--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ or as an AWS Lambda function.
 1. Download [the latest release](https://github.com/newrelic/nr-entity-tag-sync/releases)
    for your platform
 2. Extract the archive to a new directory
-3. Create a new configuration file from
-   [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
+3. Make a copy of config.yml from [the sample configuration file](configs/config.sample.yml) and place it 
+   inside 'configs' folder created at same folder location as the CMDB utility executable.
 4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ or as an AWS Lambda function.
 2. Extract the archive to a new directory
 3. Create a new configuration file from
    [the sample configuration file](configs/config.sample.yml).Place the configuration file inside 'configs' folder created at same location at CMDB utility executable
-4. Set the appropriate environment variables.'NEW_RELIC_LICENSE_KEY' is a mandatory.
+4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 ![GitHub forks](https://img.shields.io/github/forks/newrelic/nr-entity-tag-sync?style=social)
-![GitHub stars](https://img.shields.io/github/stars/newrelic/nr-entity-tag-sync?style=social)
+:![GitHub stars](https://img.shields.io/github/stars/newrelic/nr-entity-tag-sync?style=social)
 ![GitHub watchers](https://img.shields.io/github/watchers/newrelic/nr-entity-tag-sync?style=social)
 
 ![GitHub all releases](https://img.shields.io/github/downloads/newrelic/nr-entity-tag-sync/total)
@@ -255,9 +255,9 @@ or as an AWS Lambda function.
 1. Download [the latest release](https://github.com/newrelic/nr-entity-tag-sync/releases)
    for your platform
 2. Extract the archive to a new directory
-3. Make a copy of config.yml from [the sample configuration file](configs/config.sample.yml) and place it 
-   inside 'configs' folder created at same folder location as the CMDB utility executable.
-4. Set the appropriate environment variables. Environment variable 'NEW_RELIC_LICENSE_KEY' is mandatory.
+3. Create a new configuration file from
+   [the sample configuration file](configs/config.sample.yml)
+4. Set the appropriate environment variables
 5. Execute the application
 
 ### AWS Lambda Installation

--- a/pkg/interop/interop.go
+++ b/pkg/interop/interop.go
@@ -54,8 +54,6 @@ func NewInteroperability() (*Interop, error) {
 		return nil, err
   }
 
-  log.Warn(licenseKey)
-
   logger := log.New()
 
   logger.SetLevel(log.WarnLevel)


### PR DESCRIPTION
# Description

Fix to read license key from YAML file or Environment variable and start the CMDB utility. 

Current behaviour
============
During startup, license key is only recognised when set as environment variable while the value set in YAML file is ignored. If value is set in latter only then the utility startup fails with the error 'failed to create interop: license length is not 40' . The error does not mention what was missed by user.

New Behaviour
=============
Changes done to accept YAML and Environment variable as source of licenseKey. The source of license key had been listed below in increasing order of precedence. If the license key is not set in either then utility startup will fail with proper error 'New Relic license key is missing'.

- Least precedence set to read from config yaml file ( ./configs/config.yaml)
- Read from environment variable ' NEW_RELIC_LICENSE_KEY'
