### PR TITLE
fix: properly set OAuthGrantType

### DIFF
--- a/internal/provider/servicenow/servicenow.go
+++ b/internal/provider/servicenow/servicenow.go
@@ -116,6 +116,7 @@ func New(i *interop.Interop, v *viper.Viper) (provider.Provider, error) {
 			oauthClientScopes = []string{}
 		}
 
+		snp.OAuthGrantType = grantType
 		snp.OAuthTokenURL = oauthTokenUrl
 		snp.OAuthClientID = oauthClientId
 		snp.OAuthClientSecret = oauthClientSecret


### PR DESCRIPTION
# Description

Set `OAuthGrantType` to `grantType` in `servicenow.go`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
